### PR TITLE
利用自訂模式增強影像檔案搜尋功能 | Enhance image file search with custom patterns

### DIFF
--- a/py/ImagesFromFolder.py
+++ b/py/ImagesFromFolder.py
@@ -81,6 +81,16 @@ class LoadImagesFromFolder:
                 image_files.extend([f for f in os.listdir(target_dir) 
                                     if os.path.isfile(os.path.join(target_dir, f)) and
                                     f.lower().endswith(f".{ext}")])
+        else:
+            # Handles custom wildcards, prefixes, and mid-string patterns safely
+            # 安全處理自訂通配符、前綴及字串中間的模式
+            import glob from glob
+            search_path = os.path.join(folder_path, pattern)
+            
+            # Filter to ensure we only pass valid files back to the node's list
+            # 進行過濾，確保僅將有效檔案傳回節點的清單
+            image_files.extend([f for f in glob(search_path) if os.path.isfile(f)])
+
         
         image_files = sorted(image_files)
         if not image_files:


### PR DESCRIPTION
增加了對圖像檔案搜尋中自訂通配符和模式的支援

Added support for custom wildcards and patterns in image file searching.

Sorry for the bad wording, I used google translate because I wanted to respect the existing code and maintainers as much as possible and not place a burden on the reviewers. I trust that you can translate the rest of this, if you're interested reading my rationale.

The input directory needs to be flat and I have many files with prefixes, so `prefix*.png` now works.

The pattern of using endswith and only when prefixed by `*.` is very limiting. And while a small empty image is better than an error, I much prefer a more robust (and still bulletproof) search tool like glob.

I'll keep my fork/patch updated and it's available if others want to use it until then.



